### PR TITLE
ADD: openSUSE Tumbleweed Kubic Containerhost

### DIFF
--- a/etc/images.yml
+++ b/etc/images.yml
@@ -624,6 +624,8 @@ images:
       os_distro: opensuse
     tags: []
     versions:
+      - version: '20191110'
+        url: http://download.opensuse.org/tumbleweed/appliances/openSUSE-MicroOS.x86_64-16.0.0-Kubic-kubeadm-OpenStack-Cloud-Snapshot20191110.qcow2
       - version: '20191027'
         url: http://download.opensuse.org/tumbleweed/appliances/openSUSE-MicroOS.x86_64-Kubic-kubeadm-OpenStack-Cloud.qcow2
 

--- a/etc/images.yml
+++ b/etc/images.yml
@@ -629,6 +629,25 @@ images:
       - version: '20191027'
         url: http://download.opensuse.org/tumbleweed/appliances/openSUSE-MicroOS.x86_64-Kubic-kubeadm-OpenStack-Cloud.qcow2
 
+  - name: openSUSE Tumbleweed Kubic Containerhost
+    format: qcow2
+    login: opensuse
+    min_disk: 8
+    min_ram: 512
+    status: active
+    visibility: public
+    multi: true
+    meta:
+      architecture: x86_64
+      hw_disk_bus: scsi
+      hw_scsi_model: virtio-scsi
+      hw_watchdog_action: reset
+      os_distro: opensuse
+    tags: []
+    versions:
+      - version: '20191110'
+        url: http://download.opensuse.org/tumbleweed/appliances/openSUSE-MicroOS.x86_64-16.0.0-ContainerHost-OpenStack-Cloud-Snapshot20191110.qcow2
+
   - name: openSUSE Leap 42.3
     format: qcow2
     login: opensuse

--- a/etc/images.yml
+++ b/etc/images.yml
@@ -608,7 +608,7 @@ images:
 
   # openSUSE
 
-  - name: openSUSE Kubic
+  - name: openSUSE Kubic kubeadm
     format: qcow2
     login: opensuse
     min_disk: 8


### PR DESCRIPTION
There are two sorts of openSUSE Kubic Images, one that contains kubeadm to setup a Kubernetes cluster, and one that can be used as a standalone host.

- RENAME openSUSE Kubic to openSUSE Kubic kubeadm, which is the officially correct name
- ADD: openSUSE Tumbleweed Kubic Containerhost